### PR TITLE
fix: asdf latest by correctly sorting list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,14 @@
 
 set -Eeuo pipefail
 
+function sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
+    awk '{print $2}'
+}
+
 curl --silent --fail --show-error --location https://registry.npmjs.org/pnpm |
   grep -Eo '"version":"[^"]+"' |
   cut -d\" -f4 |
+  sort_versions |
   xargs


### PR DESCRIPTION
Revert to using `sort_versions` function.

`asdf latest pnpm` & `asdf install pnpm latest` behave incorrectly because `list-all` does not return a correctly sorted list of versions.