### PR TITLE
Add support for pnpm 8

### DIFF
--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -19,6 +19,7 @@ jobs:
           - 5
           - 6
           - 7
+          - 8
         node:
           - 10
           - 12
@@ -26,12 +27,19 @@ jobs:
           - 16
           - 18
         exclude:
+          # pnpm >= v8 does not support node 14
+          - node: 14
+            version: 8
+          - node: 12
+            version: 8
+          - node: 10
+            version: 8
           # pnpm >= v7 does not support node 12
           - node: 12
             version: 7
-          # pnpm >= v6 does not support node 10
           - node: 10
             version: 7
+          # pnpm >= v6 does not support node 10
           - node: 10
             version: 6
     name: plugin-test (pnpm v${{ matrix.version }}, Node.js v${{ matrix.node }}, ${{ matrix.os }})

--- a/.github/workflows/asdf_ci.yml
+++ b/.github/workflows/asdf_ci.yml
@@ -46,17 +46,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Test pnpm
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: pnpm --version
           version: latest:${{ matrix.version }}
       - name: Test pnpx
         if: matrix.version < 7
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: pnpx --version
           version: latest:${{ matrix.version }}
@@ -64,14 +64,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run ShellCheck
         run: shellcheck bin/*
   format:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install shfmt
         run: brew install shfmt
       - name: Run shfmt

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ asdf plugin-add pnpm
 ```
 
 [1]: https://asdf-vm.com/
-[2]: https://pnpm.js.org/
+[2]: https://pnpm.io/


### PR DESCRIPTION
pnpm 8 was released 2 weeks ago: https://github.com/pnpm/pnpm/releases/tag/v8.0.0

They dropped support for Node.js 14, so I've updated the matrix.