### PR TITLE
fix: use relative paths to link binaries

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,21 +20,22 @@ mkdir -p "${ASDF_INSTALL_PATH}/bin"
 
 BINARIES=('pnpm' 'pnpx')
 for bin in "${BINARIES[@]}"; do
+  # relative to ${ASDF_INSTALL_PATH}/bin
   BINARY_PATHS=(
-    "${ASDF_INSTALL_PATH}/bin/${bin}.cjs"    #v6
-    "${ASDF_INSTALL_PATH}/bin/${bin}.js"     #v2 - v5
-    "${ASDF_INSTALL_PATH}/lib/bin/${bin}.js" #v1
+    "${bin}.cjs"           #v6
+    "${bin}.js"            #v2 - v5
+    "../lib/bin/${bin}.js" #v1
   )
 
   for BINARY_PATH in "${BINARY_PATHS[@]}"; do
-    if [[ -f "${BINARY_PATH}" ]]; then
+    if [[ -f "${ASDF_INSTALL_PATH}/bin/${BINARY_PATH}" ]]; then
       BIN_PATH="${BINARY_PATH}"
       break
     fi
   done
 
   # v1 to v2 binaries are not executable
-  chmod +x "${BIN_PATH}"
+  chmod +x "${ASDF_INSTALL_PATH}/bin/${BIN_PATH}"
 
   ln -sf "${BIN_PATH}" "${ASDF_INSTALL_PATH}/bin/${bin}"
 done


### PR DESCRIPTION
I recently moved my `~/.asdf` folder to `~/.local/share/asdf`, and afterwards noticed that the `pnpm` command was broken. The problem was that the symlinks to the JS files were absolute paths that had broken because of the move.

Therefore, in this PR I've made the symlinks relative paths so that this doesn't happen again.
