### PR TITLE
Use abbreviated npm metadata format when listing versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,7 +8,13 @@ function sort_versions() {
     awk '{print $2}'
 }
 
-curl --silent --fail --show-error --location https://registry.npmjs.org/pnpm |
+curl \
+  --silent \
+  --fail \
+  --show-error \
+  --location \
+  --header 'Accept: application/vnd.npm.install-v1+json' \
+  https://registry.npmjs.org/pnpm |
   grep -Eo '"version":"[^"]+"' |
   cut -d\" -f4 |
   sort_versions |


### PR DESCRIPTION
The npm registry response for the curl in the list-versions script is currently >6 MB in size, leading to timeouts on slow connections. npm supports an abbreviated metadata format[1], which contains the version info that we need, but omits a bunch of other stuff which we don't, and is only about 1.6 MB in size currently. This change uses it.

```
# baseline:
❯ curl --silent --fail --show-error --location https://registry.npmjs.org/pnpm | wc                                 
       0  223107 6755022

# with this change:
❯ curl --silent --fail --show-error --location --header "Accept: application/vnd.npm.install-v1+json" https://registry.npmjs.org/pnpm | wc  
       0    6882 1613317
```

[1]: https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-metadata-format
