### PR TITLE
Add support for pnpm 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,21 @@ jobs:
     name: plugin-test (pnpm v${{ matrix.version }}, Node.js v${{ matrix.node }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/github-script@v7
+        id: calculate_architecture
+        with:
+          result-encoding: string
+          script: |
+            if ('${{ matrix.os }}' === 'macos-latest' && ['10', '12', '14'].includes('${{ matrix.node }}')) {
+              return "x64"
+            } else {
+              return ''
+            }
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          architecture: ${{ steps.calculate_architecture.outputs.result }}
       - name: Test pnpm
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - 6
           - 7
           - 8
+          - 9
         node:
           - 10
           - 12
@@ -28,6 +29,15 @@ jobs:
           - 18
           - 20
         exclude:
+          # pnpm >= v9 does not support node <= v16
+          - node: 10
+            version: 9
+          - node: 12
+            version: 9
+          - node: 14
+            version: 9
+          - node: 16
+            version: 9
           # pnpm >= v8 does not support node <= v14
           - node: 10
             version: 8
@@ -47,17 +57,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Test pnpm
-        uses: asdf-vm/actions/plugin-test@v2
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: pnpm --version
           version: latest:${{ matrix.version }}
       - name: Test pnpx
         if: matrix.version < 7
-        uses: asdf-vm/actions/plugin-test@v2
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: pnpx --version
           version: latest:${{ matrix.version }}
@@ -65,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run ShellCheck
         run: shellcheck bin/*
   shfmt:
@@ -75,7 +85,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: reviewdog/action-shfmt@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After adding [support for pnpm 8](https://github.com/jonathanmorley/asdf-pnpm/pull/18), I'm now adding support for pnpm 9.

pnpm 9 was released this Apr 16: https://github.com/pnpm/pnpm/releases/tag/v9.0.0

They dropped support for Node.js 16, so I've updated the matrix. Also fixed the CI that was failing.