### PR TITLE
Make npm command not required with reasonable default for registry

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,12 @@ if [[ "${ASDF_INSTALL_TYPE:-version}" == 'ref' ]]; then
   exit 1
 fi
 
-TARBALL_URL="https://registry.npmjs.org/pnpm/-/pnpm-${ASDF_INSTALL_VERSION}.tgz"
+REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
+if command -v npm 1> /dev/null; then
+  REGISTRY=$(npm config get registry)
+fi
+
+TARBALL_URL="${REGISTRY%/}/pnpm/-/pnpm-${ASDF_INSTALL_VERSION}.tgz"
 
 mkdir -p "${ASDF_INSTALL_PATH}"
 

--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ if [[ "${ASDF_INSTALL_TYPE:-version}" == 'ref' ]]; then
 fi
 
 REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
-if command -v npm 1> /dev/null; then
+if command -v npm 1>/dev/null; then
   REGISTRY=$(npm config get registry)
 fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,14 +8,18 @@ function sort_versions() {
     awk '{print $2}'
 }
 
+REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
+if command -v npm 1> /dev/null; then
+  REGISTRY=$(npm config get registry)
+fi
+
 curl \
   --silent \
   --fail \
   --show-error \
   --location \
   --header 'Accept: application/vnd.npm.install-v1+json' \
-  https://registry.npmjs.org/pnpm |
-  grep -Eo '"version":"[^"]+"' |
+  "${REGISTRY%/}/pnpm" |
+  grep -Eo '"version":\s?"[^"]+"\s?' |
   cut -d\" -f4 |
-  sort_versions |
-  xargs
+  sort_versions

--- a/bin/list-all
+++ b/bin/list-all
@@ -9,7 +9,7 @@ function sort_versions() {
 }
 
 REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
-if command -v npm 1> /dev/null; then
+if command -v npm 1>/dev/null; then
   REGISTRY=$(npm config get registry)
 fi
 


### PR DESCRIPTION
This is a new PR replacing https://github.com/jonathanmorley/asdf-pnpm/pull/23 This PR now uses a conventional ENV, then a reasonable default, making the `npm` command not necessary.

Many organizations have npmjs mirrors and will block access. This attempts to use npm config and ENV to get the configured registry so it will more universally work.

Also artifactory seems to add spaces in the response, so the regex in `list-all` is updated to be a bit more robust.

