### PR TITLE
Add support for pnpm 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - 7
           - 8
           - 9
+          - 10
         node:
           - 10
           - 12
@@ -28,7 +29,17 @@ jobs:
           - 16
           - 18
           - 20
+          - 22
         exclude:
+          # pnpm >= v10 does not support node <= v16
+          - node: 10
+            version: 10
+          - node: 12
+            version: 10
+          - node: 14
+            version: 10
+          - node: 16
+            version: 10
           # pnpm >= v9 does not support node <= v16
           - node: 10
             version: 9


### PR DESCRIPTION
After adding [support for pnpm 8](https://github.com/jonathanmorley/asdf-pnpm/pull/18) and [pnpm 9](https://github.com/jonathanmorley/asdf-pnpm/pull/24), I'm now adding support for pnpm 10.

pnpm 10 was released 2 weeks ago: https://github.com/pnpm/pnpm/releases/tag/v10.0.0

Node.js compatibility remains the same: https://pnpm.io/installation#compatibility