### PR TITLE
docs: update install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The following utilities are required:
 ## Installing
 
 ```
+asdf plugin add pnpm
+```
+
+or for asdf <0.16.0:
+
+```
 asdf plugin-add pnpm
 ```
 


### PR DESCRIPTION
asdf released version >=0.16.0: https://github.com/asdf-vm/asdf/releases/tag/v0.16.0

One of the [breaking changes](https://asdf-vm.com/guide/upgrading-to-v0-16.html#breaking-changes) is that hyphenated commands have been removed.

So this MR updates the install instructions:
- `asdf plugin-add` -> `asdf plugin add`
