### PR TITLE
fix list all from asdf sub command

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -22,4 +22,5 @@ curl \
   "${REGISTRY%/}/pnpm" |
   grep -Eo '"version":\s?"[^"]+"\s?' |
   cut -d\" -f4 |
-  sort_versions
+  sort_versions |
+  xargs


### PR DESCRIPTION
asdf list all pnpm was not working correctly, and the following output was being shown:

```
$ asdf list all pnpm
0.0.0-pr4475.1
```

By fixing the command, the correct output, as shown below, will now be produced.

```
$ asdf list all pnpm
0.0.0-pr4475.1
0.0.0-pr4475.2
...
```