### PR TITLE
Fix: pnpm latest version detection when registry has stray entries

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -23,8 +23,7 @@ fetch_versions() {
     --location \
     --header 'Accept: application/vnd.npm.install-v1+json' \
     "${reg%/}/pnpm" |
-    grep -Eo '"version":\s?"[^"]+"\s?' |
-    cut -d\" -f4 |
+    jq -r '.versions | keys[]' |
     sort_versions |
     xargs
 }


### PR DESCRIPTION
asdf was occasionally picking up bogus versions (like "24.11.0") from the npm registry metadata, causing asdf install pnpm latest to resolve incorrectly. This change filters out non-semver and stray entries before sorting, ensuring latest always picks a valid release.