### PR TITLE
fix: ignore node runtime versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -23,7 +23,7 @@ fetch_versions() {
     --location \
     --header 'Accept: application/vnd.npm.install-v1+json' \
     "${reg%/}/pnpm" |
-    grep -Eo '"version":\s?"[^"]+"\s?' |
+    grep -Eo '"version":\s?"[^"]+",\s?' |
     cut -d\" -f4 |
     sort_versions |
     xargs


### PR DESCRIPTION
It can't get simpler. :)

The reason why versions like 24 shows up is that since the 11.0.0, engine runtime version is included:
```json
      "engines": {
        "runtime": {
          "name": "node",
          "onFail": "download",
          "version": "24.11.0"
        }
      },
```

Note, that this "version" does not end with `,` so it can be filtered out just by adding `,` to the matching.
