### PR TITLE
fix: suppress npm registry check error in list all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,7 +13,7 @@ FALLBACK_REGISTRY='https://registry.npmjs.org/'
 
 REGISTRY="${NPM_CONFIG_REGISTRY:-$FALLBACK_REGISTRY/}"
 if command -v npm 1>/dev/null; then
-  REGISTRY=$(npm config get registry)
+  REGISTRY=$(npm config get registry --force 2>/dev/null)
 fi
 
 fetch_versions() {


### PR DESCRIPTION
## Description
This PR fixes an issue where the `list all` command fails in repositories that use `devengines` in `package.json` but do not configure/allow `npm`. 

Currently, the `list all` command calls `npm config get registry`. In strict environments, this triggers an environment consistency check error, causing the command to fail.

## Changes Made
Updated the registry check in the `list all` script to use `npm config get registry --force 2>/dev/null`. This safely suppresses the error and bypasses the restriction.

## Context
* This addresses a missed spot from a previous bug. The exact same underlying issue previously caused the `download` command to fail (reported in #35) and was fixed in #47. This PR applies the equivalent fix to the `list all` command.