### PR TITLE
fix: add .mjs binary path for pnpm 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
       - uses: DeterminateSystems/determinate-nix-action@527f17dd63d2d60d3e5552934bc84b9a33a14d11 # v3.22.2
         with:
+          determinate: false
           extra-conf: extra-experimental-features = ca-derivations impure-derivations
-      - uses: DeterminateSystems/flakehub-cache-action@83293488abfd33fbfb2ab084097467491c029962 # v3.22.2
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - run: nix flake check --print-build-logs --no-update-lock-file --impure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@527f17dd63d2d60d3e5552934bc84b9a33a14d11 # v3.22.2
         with:
           extra-conf: extra-experimental-features = ca-derivations impure-derivations
-      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+      - uses: DeterminateSystems/flakehub-cache-action@83293488abfd33fbfb2ab084097467491c029962 # v3.22.2
       - run: nix flake check --print-build-logs --no-update-lock-file --impure

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result/
+.worktrees/

--- a/bin/install
+++ b/bin/install
@@ -24,6 +24,7 @@ BINARIES=('pnpm' 'pnpx')
 for bin in "${BINARIES[@]}"; do
   BIN_PATH=""
   BINARY_PATHS=(
+    "${ASDF_INSTALL_PATH}/bin/${bin}.mjs"    #v12 (Rust rewrite)
     "${ASDF_INSTALL_PATH}/bin/${bin}.cjs"    #v6
     "${ASDF_INSTALL_PATH}/bin/${bin}.js"     #v2 - v5
     "${ASDF_INSTALL_PATH}/lib/bin/${bin}.js" #v1

--- a/tests/regressions.bats
+++ b/tests/regressions.bats
@@ -23,6 +23,18 @@ setup_file() {
   asdf install pnpm 10.11.0
 }
 
+# https://github.com/jonathanmorley/asdf-pnpm/issues/92
+@test "pnpm 12 installs correctly (mjs binaries)" {
+  cd "$BATS_TEST_TMPDIR"
+
+  echo '12.0.0-rc.11' >.tool-versions
+
+  asdf install
+  patchAsdf
+
+  [[ "$(pnpm --version)" == "12.0.0-rc.11" ]]
+}
+
 # https://github.com/jonathanmorley/asdf-pnpm/issues/37
 @test "correct pnpm version for 10.12.3" {
   cd "$BATS_TEST_TMPDIR"


### PR DESCRIPTION
## Summary

pnpm 12 (Rust rewrite) ships its npm-package launcher as `bin/pnpm.mjs` / `bin/pnpx.mjs` instead of `.cjs` or `.js`. This adds the `.mjs` path to `BINARY_PATHS` in `bin/install` so the install script can find the binaries.

## Changes

- `bin/install`: Added `.mjs` entry to `BINARY_PATHS` array (checked first, before `.cjs`)
- `tests/regressions.bats`: Added regression test for pnpm 12.0.0-rc.11 installation

## Testing

The new regression test verifies that pnpm 12 RC installs correctly and the binary reports the expected version.

Fixes #92
