### PR TITLE
fix pnpm 12 support and CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,10 @@ jobs:
             system: aarch64-linux
     runs-on: ${{ matrix.runner }}
     name: nix flake check (${{ matrix.system }})
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
-      - uses: DeterminateSystems/determinate-nix-action@527f17dd63d2d60d3e5552934bc84b9a33a14d11 # v3.22.2
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
-          extra-conf: extra-experimental-features = ca-derivations impure-derivations
-      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+          nix_conf: extra-experimental-features = nix-command flakes ca-derivations impure-derivations
       - run: nix flake check --print-build-logs --no-update-lock-file --impure

--- a/bin/install
+++ b/bin/install
@@ -24,6 +24,7 @@ BINARIES=('pnpm' 'pnpx')
 for bin in "${BINARIES[@]}"; do
   BIN_PATH=""
   BINARY_PATHS=(
+    "${ASDF_INSTALL_PATH}/bin/${bin}.mjs"    #v12 (Rust rewrite)
     "${ASDF_INSTALL_PATH}/bin/${bin}.cjs"    #v6
     "${ASDF_INSTALL_PATH}/bin/${bin}.js"     #v2 - v5
     "${ASDF_INSTALL_PATH}/lib/bin/${bin}.js" #v1

--- a/tests/regressions.bats
+++ b/tests/regressions.bats
@@ -27,7 +27,7 @@ setup_file() {
 @test "pnpm 12 installs correctly (mjs binaries)" {
   cd "$BATS_TEST_TMPDIR"
 
-  echo '12.2.1' >.tool-versions
+  echo 'pnpm 12.2.1' >.tool-versions
 
   asdf install
   patchAsdf

--- a/tests/regressions.bats
+++ b/tests/regressions.bats
@@ -23,6 +23,18 @@ setup_file() {
   asdf install pnpm 10.11.0
 }
 
+# https://github.com/jonathanmorley/asdf-pnpm/issues/92
+@test "pnpm 12 installs correctly (mjs binaries)" {
+  cd "$BATS_TEST_TMPDIR"
+
+  echo '12.0.0-rc.11' >.tool-versions
+
+  asdf install
+  patchAsdf
+
+  [[ "$(pnpm --version)" == "12.0.0-rc.11" ]]
+}
+
 # https://github.com/jonathanmorley/asdf-pnpm/issues/37
 @test "correct pnpm version for 10.12.3" {
   cd "$BATS_TEST_TMPDIR"

--- a/tests/regressions.bats
+++ b/tests/regressions.bats
@@ -27,12 +27,12 @@ setup_file() {
 @test "pnpm 12 installs correctly (mjs binaries)" {
   cd "$BATS_TEST_TMPDIR"
 
-  echo '12.0.0-rc.11' >.tool-versions
+  echo '12.2.1' >.tool-versions
 
   asdf install
   patchAsdf
 
-  [[ "$(pnpm --version)" == "12.0.0-rc.11" ]]
+  [[ "$(pnpm --version)" == "12.2.1" ]]
 }
 
 # https://github.com/jonathanmorley/asdf-pnpm/issues/37


### PR DESCRIPTION
## Problem

Two things were breaking the CI build:

1. **CI fails to install Nix.** `determinate-nix-action` hardcodes FlakeHub (`edge.cache.flakehub.com`) as a Nix substituter. FlakeHub requires OIDC authentication that this repo doesn't have, so `nix flake check` fails with 401 errors.

2. **Tests fail on pnpm 12.** pnpm 12 (the Rust rewrite) ships its npm-package launcher as `bin/pnpm.mjs` / `bin/pnpx.mjs` instead of `.cjs` or `.js`. The install script couldn't find the binaries, so the test suite — which now tests the latest pnpm (12.x) — fails.

## Changes

- `.github/workflows/ci.yml`: Replace `determinate-nix-action` + `magic-nix-cache-action` with `nixbuild/nix-quick-install-action@v35` (vanilla Nix, no FlakeHub). Remove the now-unneeded `id-token: write` permission; configure experimental features via `nix_conf`.
- `bin/install`: Add `.mjs` entry to `BINARY_PATHS` (checked first, before `.cjs`) for pnpm 12.
- `tests/regressions.bats`: Add regression test for pnpm 12.0.0-rc.11 installation.

## Why the previous PR (#93) CI attempts failed

Prior attempts tried switching to `flakehub-cache-action` (still requires FlakeHub auth) and setting a non-existent `determinate: false` input on `determinate-nix-action`. The correct fix for the Nix part is to use an installer that doesn't require FlakeHub at all.

Fixes #92

Supersedes #93